### PR TITLE
Use content type from gin instead of raw header

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/go-playground/validator/v10 v10.11.0
 	github.com/google/uuid v1.3.0
 	github.com/juju/errors v0.0.0-20220622220526-54a94488269b
-	github.com/mattn/go-sqlite3 v2.0.3+incompatible
+	github.com/mattn/go-sqlite3 v1.14.16
 	github.com/pires/go-proxyproto v0.6.2
 )
 

--- a/tonic/tonic.go
+++ b/tonic/tonic.go
@@ -97,14 +97,14 @@ func DefaultBindingHookMaxBodyBytes(maxBodyBytes int64) BindHook {
 			return nil
 		}
 
-		ct := c.Request.Header["Content-Type"]
+		ct := c.ContentType()
 		var b binding.Binding = binding.JSON
 
-		if len(ct) == 1 && ct[0] == binding.MIMEPOSTForm {
+		if ct == binding.MIMEPOSTForm {
 			b = binding.Form
-		} else if len(ct) == 1 && ct[0] == binding.MIMEMultipartPOSTForm {
+		} else if ct == binding.MIMEMultipartPOSTForm {
 			b = binding.FormMultipart
-		} else if len(ct) == 1 && ct[0] == binding.MIMEXML {
+		} else if ct == binding.MIMEXML {
 			b = binding.XML
 		}
 


### PR DESCRIPTION
the content type header is usually in the form `multipart/form-data; boundary=95e3d3675baf97cdfbb16cccc5074617` causing the if statement to be skipped. the ContentType() function will correctly remove these tags.